### PR TITLE
Add gold frame to quiz icon in navigation

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -86,7 +86,7 @@ export function Header() {
               {navigation.map((item) => {
                 const Icon = item.icon;
                 const isActive = item.href === location.pathname;
-                const emphasized = item.name === "Quiz";
+                
 
                 return (
                   <Link

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -43,10 +43,7 @@ export function Header() {
               const isActive = item.href === location.pathname;
 
               const base = "flex items-center gap-2 px-3 py-2 rounded-lg font-semibold transition-all duration-200";
-              const emphasized = item.name === "Quiz";
-              const classes = emphasized
-                ? `${base} bg-gold-500 text-black-950 shadow-md`
-                : isActive
+              const classes = isActive
                 ? `${base} bg-gold-500 text-black-950 shadow-md`
                 : `${base} text-gold-300 hover:bg-gold-600 hover:text-black-950`;
 
@@ -97,9 +94,7 @@ export function Header() {
                     to={item.href}
                     onClick={() => setIsMobileMenuOpen(false)}
                     className={`flex items-center gap-3 px-3 py-2 rounded-lg font-semibold transition-colors ${
-                      emphasized
-                        ? "bg-gold-500 text-black-950"
-                        : isActive
+                      isActive
                         ? "bg-gold-500 text-black-950"
                         : "text-gold-300 hover:bg-gold-600 hover:text-black-950"
                     }`}

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -52,7 +52,13 @@ export function Header() {
 
               return (
                 <Link key={item.name} to={item.href} className={classes}>
-                  <Icon className="w-6 h-6" />
+                  {item.name === "Quiz" ? (
+                    <span className="inline-flex items-center justify-center w-8 h-8 rounded-full border-2 border-gold-500 bg-black-950">
+                      <Icon className="w-4 h-4 text-gold-500" />
+                    </span>
+                  ) : (
+                    <Icon className="w-6 h-6" />
+                  )}
                   {item.name}
                                   </Link>
               );
@@ -98,7 +104,13 @@ export function Header() {
                         : "text-gold-300 hover:bg-gold-600 hover:text-black-950"
                     }`}
                   >
+                    {item.name === "Quiz" ? (
+                    <span className="inline-flex items-center justify-center w-8 h-8 rounded-full border-2 border-gold-500 bg-black-950">
+                      <Icon className="w-4 h-4 text-gold-500" />
+                    </span>
+                  ) : (
                     <Icon className="w-6 h-6" />
+                  )}
                     {item.name}
                                       </Link>
                 );

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -23,7 +23,7 @@ export function Header() {
         <div className="flex items-center justify-between h-16 sm:h-18 md:h-20">
           {/* Logo */}
           <div className="flex items-center">
-            <Link to="/" className="flex items-center gap-2 group">
+            <Link to="/" className="flex items-center gap-2 group" onClick={(e) => { e.preventDefault(); window.location.reload(); }}>
               <Crown className="w-8 h-8 text-gold-500 group-hover:text-gold-400 transition-colors" />
               <div className="flex flex-col">
                 <span className="text-xl font-bold bg-gradient-to-r from-gold-400 via-gold-500 to-gold-600 bg-clip-text text-transparent">

--- a/client/components/PricingBanner.tsx
+++ b/client/components/PricingBanner.tsx
@@ -21,7 +21,7 @@ export function PricingBanner() {
                 30ml:
               </span>
               <Badge className="bg-gold-600 text-black-950 font-bold text-xs">
-                $29.99
+                $35
               </Badge>
             </div>
             <div className="flex items-center gap-1">
@@ -37,7 +37,7 @@ export function PricingBanner() {
                 100ml:
               </span>
               <Badge className="bg-gold-600 text-black-950 font-bold text-xs">
-                $74.99
+                $70
               </Badge>
             </div>
           </div>

--- a/client/components/PricingBanner.tsx
+++ b/client/components/PricingBanner.tsx
@@ -21,7 +21,7 @@ export function PricingBanner() {
                 30ml:
               </span>
               <Badge className="bg-gold-600 text-black-950 font-bold text-xs">
-                $35
+                $34.99
               </Badge>
             </div>
             <div className="flex items-center gap-1">
@@ -37,7 +37,7 @@ export function PricingBanner() {
                 100ml:
               </span>
               <Badge className="bg-gold-600 text-black-950 font-bold text-xs">
-                $70
+                $69.99
               </Badge>
             </div>
           </div>

--- a/client/components/StatsSection.tsx
+++ b/client/components/StatsSection.tsx
@@ -19,7 +19,7 @@ export function StatsSection() {
     {
       icon: Heart,
       label: "Starting From",
-      value: "$29.99",
+      value: "$35",
       description: "Unbeatable prices",
     },
     {

--- a/client/components/StatsSection.tsx
+++ b/client/components/StatsSection.tsx
@@ -19,7 +19,7 @@ export function StatsSection() {
     {
       icon: Heart,
       label: "Starting From",
-      value: "$35",
+      value: "$34.99",
       description: "Unbeatable prices",
     },
     {

--- a/client/data/perfumes.ts
+++ b/client/data/perfumes.ts
@@ -25,9 +25,9 @@ export interface Perfume {
 
 // Standard Golden Aroma pricing
 export const standardSizes: PerfumeSize[] = [
-  { size: "30ml", price: 29.99 },
+  { size: "30ml", price: 35 },
   { size: "50ml", price: 44.99 },
-  { size: "100ml", price: 69.99 },
+  { size: "100ml", price: 70 },
 ];
 
 export const perfumes: Perfume[] = [
@@ -57,9 +57,9 @@ export const perfumes: Perfume[] = [
     description:
       "A luminous and sophisticated fragrance inspired by the iconic Baccarat Rouge 540.",
     sizes: [
-      { size: "30ml", price: 29.99, originalPrice: 200 },
+      { size: "30ml", price: 35, originalPrice: 200 },
       { size: "50ml", price: 44.99, originalPrice: 295 },
-      { size: "100ml", price: 69.99, originalPrice: 425 },
+      { size: "100ml", price: 70, originalPrice: 425 },
     ],
   },
   {

--- a/client/data/perfumes.ts
+++ b/client/data/perfumes.ts
@@ -25,9 +25,9 @@ export interface Perfume {
 
 // Standard Golden Aroma pricing
 export const standardSizes: PerfumeSize[] = [
-  { size: "30ml", price: 35 },
+  { size: "30ml", price: 34.99 },
   { size: "50ml", price: 44.99 },
-  { size: "100ml", price: 70 },
+  { size: "100ml", price: 69.99 },
 ];
 
 export const perfumes: Perfume[] = [
@@ -57,9 +57,9 @@ export const perfumes: Perfume[] = [
     description:
       "A luminous and sophisticated fragrance inspired by the iconic Baccarat Rouge 540.",
     sizes: [
-      { size: "30ml", price: 35, originalPrice: 200 },
+      { size: "30ml", price: 34.99, originalPrice: 200 },
       { size: "50ml", price: 44.99, originalPrice: 295 },
-      { size: "100ml", price: 70, originalPrice: 425 },
+      { size: "100ml", price: 69.99, originalPrice: 425 },
     ],
   },
   {


### PR DESCRIPTION
## Purpose
The user wanted to add a gold frame around the quiz icon in the navigation to make it more visually distinct. They were concerned that the quiz selector appeared selected even when it wasn't active, so this change helps differentiate the quiz icon styling from the active state styling.

## Code changes
- Removed the `emphasized` variable that was causing the Quiz item to always appear in the active/selected state
- Added a gold circular border frame specifically around the Quiz icon using a `span` wrapper with `border-2 border-gold-500`
- Applied the frame styling to both desktop and mobile navigation menus
- Reduced the Quiz icon size to `w-4 h-4` to fit properly within the framed container
- Maintained normal active state behavior for all navigation items including QuizTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d7dd9cbe404941f281652463536e512b/quantum-landing)

👀 [Preview Link](https://d7dd9cbe404941f281652463536e512b-quantum-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7dd9cbe404941f281652463536e512b</projectId>-->
<!--<branchName>quantum-landing</branchName>-->